### PR TITLE
Cpsk datematch

### DIFF
--- a/travel.py
+++ b/travel.py
@@ -75,7 +75,7 @@ def line_match(event, f, t, time=None, date=None, *args):
         bus z BA do LM 18:00 20.12.2014
         spoj zo Zochova no mlyny
     """
-    msg = event.meta["body"]
+    msg = event.meta['body']
 
     if f == t:
         return "Not in this universe."


### PR DESCRIPTION
- Plugin is now able to also match date when user specifies it in query. For instance `10.12.2014 bus z TO do BA`
- Also added more examples
- Don't throw exception when there are no results, rather return "Nothing found"

This closes #29 
