### PR TITLE
tests: Moving to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install pep8 --use-mirrors
-  - pip install pyflakes --use-mirrors
+  - pip install flake8 --use-mirrors
 script:
-  - pep8 .
-  - pyflakes .
+  - flake8 .

--- a/basic.py
+++ b/basic.py
@@ -52,7 +52,7 @@ def auto_welcome(event):
 
 
 # math functions need to be imported at runtime
-from math import *  # bypass_pyflakes
+from math import *  # NOQA
 safe_list = ['acos', 'asin', 'atan', 'atan2', 'ceil', 'cos', 'cosh',
              'degrees', 'e', 'exp', 'fabs', 'floor', 'fmod', 'frexp', 'hypot',
              'ldexp', 'log', 'log10', 'modf', 'pi', 'pow', 'radians', 'sin',


### PR DESCRIPTION
* Moved tests from pep8 and pyflakes to flake8 which wraps the two
  together and lets us easily skip tests for a given line.

Signed-off-by: mr.Shu <mr@shu.io>