### PR TITLE
basic: Escaped pattern in sed

### DIFF
--- a/basic.py
+++ b/basic.py
@@ -94,7 +94,7 @@ def eval_(event):
         return "eval: {0}".format(e)
 
 
-SED_REGEX = r'^s([^ a-zA-Z0-9])(.*?)\1(.*?)(?:\1(.+?))?$'
+SED_REGEX = r'^s([^ a-zA-Z0-9])(.*?)\1(.*?)(?:\1(.+?|))?$'
 last_events = {}
 
 

--- a/basic.py
+++ b/basic.py
@@ -125,6 +125,7 @@ def sub_match(event, sep, pattern, replacement, flags, *args, **kwargs):
     if 'i' in flags:
         flag = re.IGNORECASE
 
+    pattern = re.escape(pattern)
     details['meta']['body'] = re.sub(pattern,
                                      replacement,
                                      details['meta']['body'],


### PR DESCRIPTION
* Escaped patterns in sed so that they do not interfere with regular
  expressions.

Signed-off-by: mr.Shu <mr@shu.io>