### PR TITLE
basic: Fix for old versions of python re library

### DIFF
--- a/basic.py
+++ b/basic.py
@@ -94,7 +94,7 @@ def eval_(event):
         return "eval: {0}".format(e)
 
 
-SED_REGEX = r'^s([^ a-zA-Z0-9])(.*?)\1(.*?)(?:\1(.+?|))?$'
+SED_REGEX = r'^s([^ a-zA-Z0-9])(.*?)\1(.*?)(?:\1$|\1([a-z]+)$|$)'
 last_events = {}
 
 


### PR DESCRIPTION
* Fixed SED_REGEX so that it would also work with older versions of
  Python RE library.

Signed-off-by: mr.Shu <mr@shu.io>