### PR TITLE
url_matcher: Check file size via HEAD request

### DIFF
--- a/url_matcher.py
+++ b/url_matcher.py
@@ -14,6 +14,11 @@ WHITESPACE_RE = re.compile(r'\s\s+')
 @threaded
 @match(regex=URL_REGEX)
 def url_matcher(event, url, *args, **kwargs):
+    r = requests.head(url)
+    # files that are too big cause trouble. Let's just ignore them.
+    if r.headers['content-length'] > 5e6:
+        return
+
     html = requests.get(url).text
     readable_article = Document(html).summary().encode("utf-8")
     readable_article = TAG_RE.sub('', readable_article)


### PR DESCRIPTION
* Make sure we do not download a 100MB PDF just because it's located at
  some URL.

* This commit fixes a bug that caused issues in deployment. The constant
  5e6 reflects the author's assumption about nice, readable web
  documents at the time of commiting this piece of code.

Signed-off-by: mr.Shu <mr@shu.io>