### PR TITLE
sticky_notes: Fix issues with python __str__ magic

### DIFF
--- a/sticky_notes.py
+++ b/sticky_notes.py
@@ -25,7 +25,7 @@ class StickyNotes(BotPlugin):
         self.notes = self.open_storage('sticky_notes')
 
     def sender(self, x, event):
-        return lambda: self.msg(x, event=event)
+        return lambda: self.msg(str(x), event=event)
 
     @cmd
     def stickynote(self, event):


### PR DESCRIPTION
* It turns out one has to call `str` on objects to be sure.

Signed-off-by: mr.Shu <mr@shu.io>