### PR TITLE
sticky_notes: Fixed typos

### DIFF
--- a/sticky_notes.py
+++ b/sticky_notes.py
@@ -3,13 +3,13 @@ from brutal.core.plugin import BotPlugin, cmd, event
 
 class Note(object):
     sender = ''
-    reciever = ''
+    receiver = ''
     msg = ''
     time = None
 
-    def __init__(self, sender, reciever, msg, time=None):
+    def __init__(self, sender, receiver, msg, time=None):
         self.sender = sender
-        self.reciever = reciever
+        self.receiver = receiver
         self.msg = msg
         self.time = time
 


### PR DESCRIPTION
* It is rather tough to spell 'receiver' correctly, as it turns out. Not
  being spelled correctly caused the formatting code to thorw an
  exception (KeyError: 'receiver').