### PR TITLE
rss: Fix issue with max_stories

### DIFF
--- a/rss.py
+++ b/rss.py
@@ -33,7 +33,7 @@ class RSSPlugin(BotPlugin):
                 if entry.id == last_id:
                     break
 
-                if i >= self.max_stories:
+                if i > self.max_stories:
                     break
 
                 self.delay_task(i, self.sender(d, entry))


### PR DESCRIPTION
* The max_stories (the max number of feed items that will be messaged in
  one feed check loop) had a one-off error.

Signed-off-by: mr.Shu <mr@shu.io>