### PR TITLE
travis: Moved to new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
* Added sudo:false to .travis.yml to use the new Travis CI
  infrastructure. For more details see
  http://docs.travis-ci.com/user/migrating-from-legacy/

Signed-off-by: mr.Shu <mr@shu.io>